### PR TITLE
refactor,test: Rewrite tests using Node builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ npm install @11ty/eleventy-utils
 npm run test
 ```
 
-- We use the [ava JavaScript test runner](https://github.com/avajs/ava) ([Assertions documentation](https://github.com/avajs/ava/blob/master/docs/03-assertions.md))
+- We use the native NodeJS [test runner](https://nodejs.org/api/test.html#test-runner) and ([assertions](https://nodejs.org/api/assert.html#assert))

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Low level internal utilities to be shared amongst Eleventy projects",
   "main": "index.js",
   "scripts": {
-    "test": "npx ava --verbose"
+    "test": "node --test"
   },
   "license": "MIT",
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "funding": {
     "type": "opencollective",
@@ -33,8 +33,5 @@
   "homepage": "https://github.com/11ty/eleventy-utils/",
   "dependencies": {
     "normalize-path": "^3.0.0"
-  },
-  "devDependencies": {
-    "ava": "^4.1.0"
   }
 }

--- a/test/IsPlainObjectTest.js
+++ b/test/IsPlainObjectTest.js
@@ -1,16 +1,18 @@
-const test = require("ava");
+const assert = require("node:assert/strict")
+const test = require("node:test");
 const { isPlainObject } = require("../");
 
+
 test("isPlainObject", (t) => {
-  t.is(isPlainObject(null), false);
-  t.is(isPlainObject(undefined), false);
-  t.is(isPlainObject(1), false);
-  t.is(isPlainObject(true), false);
-  t.is(isPlainObject(false), false);
-  t.is(isPlainObject("string"), false);
-  t.is(isPlainObject([]), false);
-  t.is(isPlainObject(Symbol("a")), false);
-  t.is(
+  assert.equal(isPlainObject(null), false);
+  assert.equal(isPlainObject(undefined), false);
+  assert.equal(isPlainObject(1), false);
+  assert.equal(isPlainObject(true), false);
+  assert.equal(isPlainObject(false), false);
+  assert.equal(isPlainObject("string"), false);
+  assert.equal(isPlainObject([]), false);
+  assert.equal(isPlainObject(Symbol("a")), false);
+  assert.equal(
     isPlainObject(function () {}),
     false
   );
@@ -18,56 +20,56 @@ test("isPlainObject", (t) => {
 
 // https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/test/test.js#L11447
 // Notably, did not include the test for DOM Elements.
-test("Test from lodash.isPlainObject", (t) => {
-  t.is(isPlainObject({}), true);
-  t.is(isPlainObject({ a: 1 }), true);
+test("Test from lodash.itPlainObject", (t) => {
+  assert.equal(isPlainObject({}), true);
+  assert.equal(isPlainObject({ a: 1 }), true);
 
   function Foo(a) {
     this.a = 1;
   }
 
-  t.is(isPlainObject({ constructor: Foo }), true);
-  t.is(isPlainObject([1, 2, 3]), false);
-  t.is(isPlainObject(new Foo(1)), false);
+  assert.equal(isPlainObject({ constructor: Foo }), true);
+  assert.equal(isPlainObject([1, 2, 3]), false);
+  assert.equal(isPlainObject(new Foo(1)), false);
 });
 
-test("Test from lodash.isPlainObject: should return `true` for objects with a `[[Prototype]]` of `null`", (t) => {
+test("Test from lodash.itPlainObject: should return `true` for objects with a `[[Prototype]]` of `null`", (t) => {
   let obj = Object.create(null);
-  t.is(isPlainObject(obj), true);
+  assert.equal(isPlainObject(obj), true);
 
   obj.constructor = Object.prototype.constructor;
-  t.is(isPlainObject(obj), true);
+  assert.equal(isPlainObject(obj), true);
 });
 
-test("Test from lodash.isPlainObject: should return `true` for objects with a `valueOf` property", (t) => {
-  t.is(isPlainObject({ valueOf: 0 }), true);
+test("Test from lodash.itPlainObject: should return `true` for objects with a `valueOf` property", (t) => {
+  assert.equal(isPlainObject({ valueOf: 0 }), true);
 });
 
-test("Test from lodash.isPlainObject: should return `true` for objects with a writable `Symbol.toStringTag` property", (t) => {
+test("Test from lodash.itPlainObject: should return `true` for objects with a writable `Symbol.toStringTag` property", (t) => {
   let obj = {};
   obj[Symbol.toStringTag] = "X";
 
-  t.is(isPlainObject(obj), true);
+  assert.equal(isPlainObject(obj), true);
 });
 
-test("Test from lodash.isPlainObject: should return `false` for objects with a custom `[[Prototype]]`", (t) => {
+test("Test from lodash.itPlainObject: should return `false` for objects with a custom `[[Prototype]]`", (t) => {
   let obj = Object.create({ a: 1 });
-  t.is(isPlainObject(obj), false);
+  assert.equal(isPlainObject(obj), false);
 });
 
-test("Test from lodash.isPlainObject (modified): should return `false` for non-Object objects", (t) => {
-  t.is(isPlainObject(arguments), true); // WARNING: lodash was false
-  t.is(isPlainObject(Error), false);
-  t.is(isPlainObject(Math), true); // WARNING: lodash was false
+test("Test from lodash.itPlainObject (modified): should return `false` for non-Object objects", (t) => {
+  assert.equal(isPlainObject(arguments), true); // WARNING: lodash was false
+  assert.equal(isPlainObject(Error), false);
+  assert.equal(isPlainObject(Math), true); // WARNING: lodash was false
 });
 
-test("Test from lodash.isPlainObject: should return `false` for non-objects", (t) => {
-  t.is(isPlainObject(true), false);
-  t.is(isPlainObject("a"), false);
-  t.is(isPlainObject(Symbol("a")), false);
+test("Test from lodash.itPlainObject: should return `false` for non-objects", (t) => {
+  assert.equal(isPlainObject(true), false);
+  assert.equal(isPlainObject("a"), false);
+  assert.equal(isPlainObject(Symbol("a")), false);
 });
 
-test("Test from lodash.isPlainObject (modified): should return `true` for objects with a read-only `Symbol.toStringTag` property", (t) => {
+test("Test from lodash.itPlainObject (modified): should return `true` for objects with a read-only `Symbol.toStringTag` property", (t) => {
   var object = {};
   Object.defineProperty(object, Symbol.toStringTag, {
     configurable: true,
@@ -76,5 +78,5 @@ test("Test from lodash.isPlainObject (modified): should return `true` for object
     value: "X",
   });
 
-  t.is(isPlainObject(object), true); // WARNING: lodash was false
+  assert.equal(isPlainObject(object), true); // WARNING: lodash was false
 });

--- a/test/TemplatePathTest.js
+++ b/test/TemplatePathTest.js
@@ -1,50 +1,51 @@
-const test = require("ava");
-const fs = require("fs");
-const path = require("path");
+const assert = require("node:assert/strict")
+const test = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
 const { TemplatePath } = require("../");
 
 test("getDir", (t) => {
-  t.is(TemplatePath.getDir("README.md"), ".");
-  t.is(TemplatePath.getDir("test/stubs/config.js"), "test/stubs");
-  t.is(TemplatePath.getDir("./test/stubs/config.js"), "./test/stubs");
-  t.is(TemplatePath.getDir("test/stubs/*.md"), "test/stubs");
-  t.is(TemplatePath.getDir("test/stubs/**"), "test/stubs");
-  t.is(TemplatePath.getDir("test/stubs/!(multiple.md)"), "test/stubs");
+  assert.equal(TemplatePath.getDir("README.md"), ".");
+  assert.equal(TemplatePath.getDir("test/stubs/config.js"), "test/stubs");
+  assert.equal(TemplatePath.getDir("./test/stubs/config.js"), "./test/stubs");
+  assert.equal(TemplatePath.getDir("test/stubs/*.md"), "test/stubs");
+  assert.equal(TemplatePath.getDir("test/stubs/**"), "test/stubs");
+  assert.equal(TemplatePath.getDir("test/stubs/!(multiple.md)"), "test/stubs");
 });
 
 test("getDirFromFilePath", (t) => {
-  t.is(TemplatePath.getDirFromFilePath("test/stubs/*.md"), "test/stubs");
-  t.is(TemplatePath.getDirFromFilePath("test/stubs/!(x.md)"), "test/stubs");
+  assert.equal(TemplatePath.getDirFromFilePath("test/stubs/*.md"), "test/stubs");
+  assert.equal(TemplatePath.getDirFromFilePath("test/stubs/!(x.md)"), "test/stubs");
 });
 
 test("getLastPathSegment", (t) => {
-  t.is(TemplatePath.getLastPathSegment("./testing/hello"), "hello");
-  t.is(TemplatePath.getLastPathSegment("./testing"), "testing");
-  t.is(TemplatePath.getLastPathSegment("./testing/"), "testing");
-  t.is(TemplatePath.getLastPathSegment("testing/"), "testing");
-  t.is(TemplatePath.getLastPathSegment("testing"), "testing");
+  assert.equal(TemplatePath.getLastPathSegment("./testing/hello"), "hello");
+  assert.equal(TemplatePath.getLastPathSegment("./testing"), "testing");
+  assert.equal(TemplatePath.getLastPathSegment("./testing/"), "testing");
+  assert.equal(TemplatePath.getLastPathSegment("testing/"), "testing");
+  assert.equal(TemplatePath.getLastPathSegment("testing"), "testing");
 });
 
 test("getAllDirs", (t) => {
-  t.deepEqual(TemplatePath.getAllDirs("."), ["."]);
-  t.deepEqual(TemplatePath.getAllDirs("./"), ["."]);
-  t.deepEqual(TemplatePath.getAllDirs("./testing"), ["./testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("./testing/"), ["./testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("testing/"), ["testing"]);
-  t.deepEqual(TemplatePath.getAllDirs("testing"), ["testing"]);
+  assert.deepEqual(TemplatePath.getAllDirs("."), ["."]);
+  assert.deepEqual(TemplatePath.getAllDirs("./"), ["."]);
+  assert.deepEqual(TemplatePath.getAllDirs("./testing"), ["./testing"]);
+  assert.deepEqual(TemplatePath.getAllDirs("./testing/"), ["./testing"]);
+  assert.deepEqual(TemplatePath.getAllDirs("testing/"), ["testing"]);
+  assert.deepEqual(TemplatePath.getAllDirs("testing"), ["testing"]);
 
-  t.deepEqual(TemplatePath.getAllDirs("./testing/hello"), [
+  assert.deepEqual(TemplatePath.getAllDirs("./testing/hello"), [
     "./testing/hello",
     "./testing",
   ]);
 
-  t.deepEqual(TemplatePath.getAllDirs("./src/collections/posts"), [
+  assert.deepEqual(TemplatePath.getAllDirs("./src/collections/posts"), [
     "./src/collections/posts",
     "./src/collections",
     "./src",
   ]);
 
-  t.deepEqual(
+  assert.deepEqual(
     TemplatePath.getAllDirs("./src/site/content/en/paths/performanceAudits"),
     [
       "./src/site/content/en/paths/performanceAudits",
@@ -56,13 +57,13 @@ test("getAllDirs", (t) => {
     ]
   );
 
-  t.deepEqual(TemplatePath.getAllDirs("./src/_site/src"), [
+  assert.deepEqual(TemplatePath.getAllDirs("./src/_site/src"), [
     "./src/_site/src",
     "./src/_site",
     "./src",
   ]);
 
-  t.deepEqual(TemplatePath.getAllDirs("./src/_site/src/src/src"), [
+  assert.deepEqual(TemplatePath.getAllDirs("./src/_site/src/src/src"), [
     "./src/_site/src/src/src",
     "./src/_site/src/src",
     "./src/_site/src",
@@ -72,95 +73,95 @@ test("getAllDirs", (t) => {
 });
 
 test("normalize", async (t) => {
-  t.is(TemplatePath.normalize(""), ".");
-  t.is(TemplatePath.normalize("."), ".");
-  t.is(TemplatePath.normalize("/"), "/");
-  t.is(TemplatePath.normalize("/testing"), "/testing");
-  t.is(TemplatePath.normalize("/testing/"), "/testing");
+  assert.equal(TemplatePath.normalize(""), ".");
+  assert.equal(TemplatePath.normalize("."), ".");
+  assert.equal(TemplatePath.normalize("/"), "/");
+  assert.equal(TemplatePath.normalize("/testing"), "/testing");
+  assert.equal(TemplatePath.normalize("/testing/"), "/testing");
 
   // v0.4.0 changed from `./` to `.`
   // normalize removes trailing slashes so it should probably be `.`
-  t.is(TemplatePath.normalize("./"), ".");
-  t.is(TemplatePath.normalize("./testing"), "testing");
+  assert.equal(TemplatePath.normalize("./"), ".");
+  assert.equal(TemplatePath.normalize("./testing"), "testing");
 
-  t.is(TemplatePath.normalize("../"), "..");
-  t.is(TemplatePath.normalize("../testing"), "../testing");
+  assert.equal(TemplatePath.normalize("../"), "..");
+  assert.equal(TemplatePath.normalize("../testing"), "../testing");
 
-  t.is(TemplatePath.normalize("./testing/hello"), "testing/hello");
-  t.is(TemplatePath.normalize("./testing/hello/"), "testing/hello");
+  assert.equal(TemplatePath.normalize("./testing/hello"), "testing/hello");
+  assert.equal(TemplatePath.normalize("./testing/hello/"), "testing/hello");
 
-  t.is(TemplatePath.normalize(".htaccess"), ".htaccess");
+  assert.equal(TemplatePath.normalize(".htaccess"), ".htaccess");
 });
 
 test("join", async (t) => {
-  t.is(TemplatePath.join("src", "_includes"), "src/_includes");
-  t.is(TemplatePath.join("src", "_includes/"), "src/_includes");
-  t.is(TemplatePath.join("src", "/_includes"), "src/_includes");
-  t.is(TemplatePath.join("src", "./_includes"), "src/_includes");
-  t.is(TemplatePath.join("src", "//_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("src", "_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("src", "_includes/"), "src/_includes");
+  assert.equal(TemplatePath.join("src", "/_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("src", "./_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("src", "//_includes"), "src/_includes");
 
-  t.is(TemplatePath.join("./src", "_includes"), "src/_includes");
-  t.is(TemplatePath.join("./src", "_includes/"), "src/_includes");
-  t.is(TemplatePath.join("./src", "/_includes"), "src/_includes");
-  t.is(TemplatePath.join("./src", "./_includes"), "src/_includes");
-  t.is(TemplatePath.join("./src", "//_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("./src", "_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("./src", "_includes/"), "src/_includes");
+  assert.equal(TemplatePath.join("./src", "/_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("./src", "./_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("./src", "//_includes"), "src/_includes");
 
-  t.is(TemplatePath.join("src", "test", "..", "_includes"), "src/_includes");
+  assert.equal(TemplatePath.join("src", "test", "..", "_includes"), "src/_includes");
 });
 
 test("normalizeUrlPath", (t) => {
-  t.is(TemplatePath.normalizeUrlPath(""), ".");
-  t.is(TemplatePath.normalizeUrlPath("."), ".");
-  t.is(TemplatePath.normalizeUrlPath("./"), "./");
-  t.is(TemplatePath.normalizeUrlPath(".."), "..");
-  t.is(TemplatePath.normalizeUrlPath("../"), "../");
+  assert.equal(TemplatePath.normalizeUrlPath(""), ".");
+  assert.equal(TemplatePath.normalizeUrlPath("."), ".");
+  assert.equal(TemplatePath.normalizeUrlPath("./"), "./");
+  assert.equal(TemplatePath.normalizeUrlPath(".."), "..");
+  assert.equal(TemplatePath.normalizeUrlPath("../"), "../");
 
-  t.is(TemplatePath.normalizeUrlPath("/"), "/");
-  t.is(TemplatePath.normalizeUrlPath("//"), "/");
-  t.is(TemplatePath.normalizeUrlPath("/../"), "/");
-  t.is(TemplatePath.normalizeUrlPath("/test"), "/test");
-  t.is(TemplatePath.normalizeUrlPath("/test/"), "/test/");
-  t.is(TemplatePath.normalizeUrlPath("/test//"), "/test/");
-  t.is(TemplatePath.normalizeUrlPath("/test/../"), "/");
-  t.is(TemplatePath.normalizeUrlPath("/test/../../"), "/");
+  assert.equal(TemplatePath.normalizeUrlPath("/"), "/");
+  assert.equal(TemplatePath.normalizeUrlPath("//"), "/");
+  assert.equal(TemplatePath.normalizeUrlPath("/../"), "/");
+  assert.equal(TemplatePath.normalizeUrlPath("/test"), "/test");
+  assert.equal(TemplatePath.normalizeUrlPath("/test/"), "/test/");
+  assert.equal(TemplatePath.normalizeUrlPath("/test//"), "/test/");
+  assert.equal(TemplatePath.normalizeUrlPath("/test/../"), "/");
+  assert.equal(TemplatePath.normalizeUrlPath("/test/../../"), "/");
 });
 
 test("absolutePath", (t) => {
-  t.is(
+  assert.equal(
     TemplatePath.absolutePath(".eleventy.js").split("/").pop(),
     ".eleventy.js"
   );
-  t.is(TemplatePath.absolutePath("/tmp/.eleventy.js"), "/tmp/.eleventy.js");
-  t.is(
+  assert.equal(TemplatePath.absolutePath("/tmp/.eleventy.js"), "/tmp/.eleventy.js");
+  assert.equal(
     TemplatePath.absolutePath("/var/task/", ".eleventy.js"),
     "/var/task/.eleventy.js"
   );
 
-  t.throws(() => {
+  assert.throws(() => {
     TemplatePath.absolutePath("/var/task/", "/var/task/.eleventy.js");
   });
 
-  t.throws(() => {
+  assert.throws(() => {
     TemplatePath.absolutePath("file1.js", "test/file2.js", "/tmp/.eleventy.js");
   });
 });
 
 test("absolutePath and relativePath", (t) => {
-  t.is(
+  assert.equal(
     TemplatePath.relativePath(TemplatePath.absolutePath(".eleventy.js")),
     ".eleventy.js"
   );
 });
 
 test("addLeadingDotSlash", (t) => {
-  t.is(TemplatePath.addLeadingDotSlash("."), "./");
-  t.is(TemplatePath.addLeadingDotSlash(".."), "../");
-  t.is(TemplatePath.addLeadingDotSlash("./test/stubs"), "./test/stubs");
-  t.is(TemplatePath.addLeadingDotSlash("./dist"), "./dist");
-  t.is(TemplatePath.addLeadingDotSlash("../dist"), "../dist");
-  t.is(TemplatePath.addLeadingDotSlash("/dist"), "/dist");
-  t.is(TemplatePath.addLeadingDotSlash("dist"), "./dist");
-  t.is(TemplatePath.addLeadingDotSlash(".nyc_output"), "./.nyc_output");
+  assert.equal(TemplatePath.addLeadingDotSlash("."), "./");
+  assert.equal(TemplatePath.addLeadingDotSlash(".."), "../");
+  assert.equal(TemplatePath.addLeadingDotSlash("./test/stubs"), "./test/stubs");
+  assert.equal(TemplatePath.addLeadingDotSlash("./dist"), "./dist");
+  assert.equal(TemplatePath.addLeadingDotSlash("../dist"), "../dist");
+  assert.equal(TemplatePath.addLeadingDotSlash("/dist"), "/dist");
+  assert.equal(TemplatePath.addLeadingDotSlash("dist"), "./dist");
+  assert.equal(TemplatePath.addLeadingDotSlash(".nyc_output"), "./.nyc_output");
 
   // TODO How to test this on Windows? path.isAbsolute is OS dependent 😱
   // let windowsAbsolutePath = `C:\\Users\\$USER\\$PROJECT\\netlify\\functions\\serverless\\index`;
@@ -168,54 +169,55 @@ test("addLeadingDotSlash", (t) => {
 });
 
 test("addLeadingDotSlashArray", (t) => {
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray(["."]), ["./"]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray([".."]), ["../"]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray(["./test/stubs"]), [
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray(["."]), ["./"]);
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray([".."]), ["../"]);
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray(["./test/stubs"]), [
     "./test/stubs",
   ]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray(["./dist"]), ["./dist"]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray(["../dist"]), ["../dist"]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray(["/dist"]), ["/dist"]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray(["dist"]), ["./dist"]);
-  t.deepEqual(TemplatePath.addLeadingDotSlashArray([".nyc_output"]), [
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray(["./dist"]), ["./dist"]);
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray(["../dist"]), ["../dist"]);
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray(["/dist"]), ["/dist"]);
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray(["dist"]), ["./dist"]);
+  assert.deepEqual(TemplatePath.addLeadingDotSlashArray([".nyc_output"]), [
     "./.nyc_output",
   ]);
 });
 
 test("stripLeadingDotSlash", (t) => {
-  t.is(TemplatePath.stripLeadingDotSlash("./test/stubs"), "test/stubs");
-  t.is(TemplatePath.stripLeadingDotSlash("./dist"), "dist");
-  t.is(TemplatePath.stripLeadingDotSlash("../dist"), "../dist");
-  t.is(TemplatePath.stripLeadingDotSlash("dist"), "dist");
+  assert.equal(TemplatePath.stripLeadingDotSlash("./test/stubs"), "test/stubs");
+  assert.equal(TemplatePath.stripLeadingDotSlash("./dist"), "dist");
+  assert.equal(TemplatePath.stripLeadingDotSlash("../dist"), "../dist");
+  assert.equal(TemplatePath.stripLeadingDotSlash("dist"), "dist");
 
-  t.is(TemplatePath.stripLeadingDotSlash(".htaccess"), ".htaccess");
+  assert.equal(TemplatePath.stripLeadingDotSlash(".htaccess"), ".htaccess");
 });
 
 test("startsWithSubPath", (t) => {
-  t.false(TemplatePath.startsWithSubPath("./testing/hello", "./lskdjklfjz"));
-  t.false(TemplatePath.startsWithSubPath("./testing/hello", "lskdjklfjz"));
-  t.false(TemplatePath.startsWithSubPath("testing/hello", "./lskdjklfjz"));
-  t.false(TemplatePath.startsWithSubPath("testing/hello", "lskdjklfjz"));
+  assert.equal(false, TemplatePath.startsWithSubPath("./testing/hello", "./lskdjklfjz"));
+  assert.equal(false, TemplatePath.startsWithSubPath("./testing/hello", "lskdjklfjz"));
+  assert.equal(false, TemplatePath.startsWithSubPath("testing/hello", "./lskdjklfjz"));
+  assert.equal(false, TemplatePath.startsWithSubPath("testing/hello", "lskdjklfjz"));
 
-  t.true(TemplatePath.startsWithSubPath("./testing/hello", "./testing"));
-  t.true(TemplatePath.startsWithSubPath("./testing/hello", "testing"));
-  t.true(TemplatePath.startsWithSubPath("testing/hello", "./testing"));
-  t.true(TemplatePath.startsWithSubPath("testing/hello", "testing"));
+  assert.equal(true, TemplatePath.startsWithSubPath("./testing/hello", "./testing"));
+  assert.equal(true, TemplatePath.startsWithSubPath("./testing/hello", "testing"));
+  assert.equal(true, TemplatePath.startsWithSubPath("testing/hello", "./testing"));
+  assert.equal(true, TemplatePath.startsWithSubPath("testing/hello", "testing"));
 
-  t.true(
+  assert.equal(true,
     TemplatePath.startsWithSubPath("testing/hello/subdir/test", "testing")
   );
-  t.false(TemplatePath.startsWithSubPath("testing/hello/subdir/test", "hello"));
-  t.false(
+  assert.equal(false,
+    TemplatePath.startsWithSubPath("testing/hello/subdir/test", "hello"));
+  assert.equal(false,
     TemplatePath.startsWithSubPath("testing/hello/subdir/test", "hello/subdir")
   );
-  t.true(
+  assert.equal(true,
     TemplatePath.startsWithSubPath(
       "testing/hello/subdir/test",
       "testing/hello/subdir"
     )
   );
-  t.true(
+  assert.equal(true,
     TemplatePath.startsWithSubPath(
       "testing/hello/subdir/test",
       "testing/hello/subdir/test"
@@ -224,146 +226,146 @@ test("startsWithSubPath", (t) => {
 });
 
 test("stripLeadingSubPath", (t) => {
-  t.is(
+  assert.equal(
     TemplatePath.stripLeadingSubPath("./testing/hello", "./lskdjklfjz"),
     "testing/hello"
   );
-  t.is(TemplatePath.stripLeadingSubPath("./test/stubs", "stubs"), "test/stubs");
-  t.is(TemplatePath.stripLeadingSubPath("./test/stubs", "./test"), "stubs");
-  t.is(TemplatePath.stripLeadingSubPath("./testing/hello", "testing"), "hello");
-  t.is(TemplatePath.stripLeadingSubPath("testing/hello", "testing"), "hello");
-  t.is(TemplatePath.stripLeadingSubPath("testing/hello", "./testing"), "hello");
-  t.is(
+  assert.equal(TemplatePath.stripLeadingSubPath("./test/stubs", "stubs"), "test/stubs");
+  assert.equal(TemplatePath.stripLeadingSubPath("./test/stubs", "./test"), "stubs");
+  assert.equal(TemplatePath.stripLeadingSubPath("./testing/hello", "testing"), "hello");
+  assert.equal(TemplatePath.stripLeadingSubPath("testing/hello", "testing"), "hello");
+  assert.equal(TemplatePath.stripLeadingSubPath("testing/hello", "./testing"), "hello");
+  assert.equal(
     TemplatePath.stripLeadingSubPath("testing/hello/subdir/test", "testing"),
     "hello/subdir/test"
   );
 
-  t.is(TemplatePath.stripLeadingSubPath(".htaccess", "./"), ".htaccess");
-  t.is(TemplatePath.stripLeadingSubPath(".htaccess", "."), ".htaccess");
+  assert.equal(TemplatePath.stripLeadingSubPath(".htaccess", "./"), ".htaccess");
+  assert.equal(TemplatePath.stripLeadingSubPath(".htaccess", "."), ".htaccess");
 });
 
 test("convertToRecursiveGlobSync", (t) => {
-  t.is(TemplatePath.convertToRecursiveGlobSync(""), "./**");
-  t.is(TemplatePath.convertToRecursiveGlobSync("."), "./**");
-  t.is(TemplatePath.convertToRecursiveGlobSync("./"), "./**");
-  t.is(
+  assert.equal(TemplatePath.convertToRecursiveGlobSync(""), "./**");
+  assert.equal(TemplatePath.convertToRecursiveGlobSync("."), "./**");
+  assert.equal(TemplatePath.convertToRecursiveGlobSync("./"), "./**");
+  assert.equal(
     TemplatePath.convertToRecursiveGlobSync("test/stubs"),
     "./test/stubs/**"
   );
-  t.is(
+  assert.equal(
     TemplatePath.convertToRecursiveGlobSync("test/stubs/"),
     "./test/stubs/**"
   );
-  t.is(
+  assert.equal(
     TemplatePath.convertToRecursiveGlobSync("./test/stubs/"),
     "./test/stubs/**"
   );
-  t.is(
+  assert.equal(
     TemplatePath.convertToRecursiveGlobSync("./test/stubs/config.js"),
     "./test/stubs/config.js"
   );
 });
 
 test("convertToRecursiveGlob", async (t) => {
-  t.is(await TemplatePath.convertToRecursiveGlob(""), "./**");
-  t.is(await TemplatePath.convertToRecursiveGlob("."), "./**");
-  t.is(await TemplatePath.convertToRecursiveGlob("./"), "./**");
-  t.is(
+  assert.equal(await TemplatePath.convertToRecursiveGlob(""), "./**");
+  assert.equal(await TemplatePath.convertToRecursiveGlob("."), "./**");
+  assert.equal(await TemplatePath.convertToRecursiveGlob("./"), "./**");
+  assert.equal(
     await TemplatePath.convertToRecursiveGlob("test/stubs"),
     "./test/stubs/**"
   );
-  t.is(
+  assert.equal(
     await TemplatePath.convertToRecursiveGlob("test/stubs/"),
     "./test/stubs/**"
   );
-  t.is(
+  assert.equal(
     await TemplatePath.convertToRecursiveGlob("./test/stubs/"),
     "./test/stubs/**"
   );
-  t.is(
+  assert.equal(
     await TemplatePath.convertToRecursiveGlob("./test/stubs/config.js"),
     "./test/stubs/config.js"
   );
 });
 
 test("getExtension", (t) => {
-  t.is(TemplatePath.getExtension(""), "");
-  t.is(TemplatePath.getExtension("test/stubs"), "");
-  t.is(TemplatePath.getExtension("test/stubs.njk"), "njk");
-  t.is(TemplatePath.getExtension("test/stubs.hbs"), "hbs");
+  assert.equal(TemplatePath.getExtension(""), "");
+  assert.equal(TemplatePath.getExtension("test/stubs"), "");
+  assert.equal(TemplatePath.getExtension("test/stubs.njk"), "njk");
+  assert.equal(TemplatePath.getExtension("test/stubs.hbs"), "hbs");
   // Not normalized to template extension map
-  t.is(TemplatePath.getExtension("test/stubs.11ty.js"), "js");
+  assert.equal(TemplatePath.getExtension("test/stubs.11ty.js"), "js");
 });
 
 test("removeExtension", (t) => {
-  t.is(TemplatePath.removeExtension(""), "");
-  t.is(TemplatePath.removeExtension("", "hbs"), "");
+  assert.equal(TemplatePath.removeExtension(""), "");
+  assert.equal(TemplatePath.removeExtension("", "hbs"), "");
 
-  t.is(TemplatePath.removeExtension("test/stubs", "hbs"), "test/stubs");
-  t.is(TemplatePath.removeExtension("test/stubs.njk"), "test/stubs.njk");
-  t.is(TemplatePath.removeExtension("test/stubs.njk", "hbs"), "test/stubs.njk");
-  t.is(TemplatePath.removeExtension("test/stubs.hbs", "hbs"), "test/stubs");
+  assert.equal(TemplatePath.removeExtension("test/stubs", "hbs"), "test/stubs");
+  assert.equal(TemplatePath.removeExtension("test/stubs.njk"), "test/stubs.njk");
+  assert.equal(TemplatePath.removeExtension("test/stubs.njk", "hbs"), "test/stubs.njk");
+  assert.equal(TemplatePath.removeExtension("test/stubs.hbs", "hbs"), "test/stubs");
 
-  t.is(TemplatePath.removeExtension("./test/stubs.njk"), "./test/stubs.njk");
-  t.is(
+  assert.equal(TemplatePath.removeExtension("./test/stubs.njk"), "./test/stubs.njk");
+  assert.equal(
     TemplatePath.removeExtension("./test/stubs.njk", "hbs"),
     "./test/stubs.njk"
   );
-  t.is(TemplatePath.removeExtension("./test/stubs.hbs", "hbs"), "./test/stubs");
+  assert.equal(TemplatePath.removeExtension("./test/stubs.hbs", "hbs"), "./test/stubs");
 
-  t.is(TemplatePath.removeExtension("test/stubs", ".hbs"), "test/stubs");
-  t.is(
+  assert.equal(TemplatePath.removeExtension("test/stubs", ".hbs"), "test/stubs");
+  assert.equal(
     TemplatePath.removeExtension("test/stubs.njk", ".hbs"),
     "test/stubs.njk"
   );
-  t.is(TemplatePath.removeExtension("test/stubs.hbs", ".hbs"), "test/stubs");
-  t.is(
+  assert.equal(TemplatePath.removeExtension("test/stubs.hbs", ".hbs"), "test/stubs");
+  assert.equal(
     TemplatePath.removeExtension("./test/stubs.njk", ".hbs"),
     "./test/stubs.njk"
   );
-  t.is(
+  assert.equal(
     TemplatePath.removeExtension("./test/stubs.hbs", ".hbs"),
     "./test/stubs"
   );
 });
 
 test("isDirectorySync", (t) => {
-  t.is(TemplatePath.isDirectorySync("asdlkfjklsadjflkja"), false);
-  t.is(TemplatePath.isDirectorySync("test"), true);
-  t.is(TemplatePath.isDirectorySync("test/stubs"), true);
-  t.is(TemplatePath.isDirectorySync("test/stubs/.eleventyignore"), false);
+  assert.equal(TemplatePath.isDirectorySync("asdlkfjklsadjflkja"), false);
+  assert.equal(TemplatePath.isDirectorySync("test"), true);
+  assert.equal(TemplatePath.isDirectorySync("test/stubs"), true);
+  assert.equal(TemplatePath.isDirectorySync("test/stubs/.eleventyignore"), false);
 });
 
 test("isDirectory", async (t) => {
-  t.is(await TemplatePath.isDirectory("asdlkfjklsadjflkja"), false);
-  t.is(await TemplatePath.isDirectory("test"), true);
-  t.is(await TemplatePath.isDirectory("test/stubs"), true);
-  t.is(await TemplatePath.isDirectory("test/stubs/.eleventyignore"), false);
+  assert.equal(await TemplatePath.isDirectory("asdlkfjklsadjflkja"), false);
+  assert.equal(await TemplatePath.isDirectory("test"), true);
+  assert.equal(await TemplatePath.isDirectory("test/stubs"), true);
+  assert.equal(await TemplatePath.isDirectory("test/stubs/.eleventyignore"), false);
 });
 
 test("exists", async (t) => {
-  t.is(fs.existsSync("asdlkfjklsadjflkja"), false);
-  t.is(fs.existsSync("test"), true);
-  t.is(fs.existsSync("test/stubs"), true);
-  t.is(fs.existsSync("test/stubs/.eleventyignore"), true);
+  assert.equal(fs.existsSync("asdlkfjklsadjflkja"), false);
+  assert.equal(fs.existsSync("test"), true);
+  assert.equal(fs.existsSync("test/stubs"), true);
+  assert.equal(fs.existsSync("test/stubs/.eleventyignore"), true);
 });
 
 test("standardize", async (t) => {
-  t.is(TemplatePath.standardizeFilePath(""), "./");
-  t.is(TemplatePath.standardizeFilePath("."), "./");
-  t.is(TemplatePath.standardizeFilePath("./"), "./");
-  t.is(TemplatePath.standardizeFilePath("/"), "/");
-  t.is(TemplatePath.standardizeFilePath("/testing"), "/testing");
-  t.is(TemplatePath.standardizeFilePath("/testing/"), "/testing/");
+  assert.equal(TemplatePath.standardizeFilePath(""), "./");
+  assert.equal(TemplatePath.standardizeFilePath("."), "./");
+  assert.equal(TemplatePath.standardizeFilePath("./"), "./");
+  assert.equal(TemplatePath.standardizeFilePath("/"), "/");
+  assert.equal(TemplatePath.standardizeFilePath("/testing"), "/testing");
+  assert.equal(TemplatePath.standardizeFilePath("/testing/"), "/testing/");
 
-  t.is(TemplatePath.standardizeFilePath("./testing"), "./testing");
+  assert.equal(TemplatePath.standardizeFilePath("./testing"), "./testing");
 
-  t.is(TemplatePath.standardizeFilePath("../"), "../");
-  t.is(TemplatePath.standardizeFilePath("../testing"), "../testing");
+  assert.equal(TemplatePath.standardizeFilePath("../"), "../");
+  assert.equal(TemplatePath.standardizeFilePath("../testing"), "../testing");
 
-  t.is(TemplatePath.standardizeFilePath("./testing/hello"), "./testing/hello");
-  t.is(TemplatePath.standardizeFilePath("./testing/hello/"), "./testing/hello/");
+  assert.equal(TemplatePath.standardizeFilePath("./testing/hello"), "./testing/hello");
+  assert.equal(TemplatePath.standardizeFilePath("./testing/hello/"), "./testing/hello/");
 
-  t.is(TemplatePath.standardizeFilePath(".htaccess"), "./.htaccess");
-  t.is(TemplatePath.standardizeFilePath(`${path.sep}Users${path.sep}test`), "/Users/test");
+  assert.equal(TemplatePath.standardizeFilePath(".htaccess"), "./.htaccess");
+  assert.equal(TemplatePath.standardizeFilePath(`${path.sep}Users${path.sep}test`), "/Users/test");
 });


### PR DESCRIPTION
You [mentioned on Mastodon](https://mastodon.social/@zachleat@zachleat.com/111698070327098778) that you might be interested in refactoring some tests to use the native Node.js test runner (and drop `ava` from `devDependencies`).

**Note:** 
- The test runner was introduced in Node v18, so I adjusted `package.json` accordingly.
- The <code>node:<var>moduleName</var></code> syntax was introduced in Node v16; since the required engine is now v18, I used the `node:` protocol in the test’s `require()` calls.